### PR TITLE
fix(ci): skip docs:fix-urls in deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -54,7 +54,12 @@ jobs:
           cache-dependency-path: docs-site/package-lock.json
 
       - name: Generate API reference (deno doc)
-        run: deno task docs:build
+        # Skip docs:fix-urls (renames ~ → __SYMBOLS__ for Deno Deploy URL
+        # compatibility) — Cloudflare Workers Assets handles ~ paths natively,
+        # and the script has a walk()+rename race that crashes in CI. See #11.
+        run: |
+          deno task docs
+          deno task docs:enhance
 
       - name: Install docs-site dependencies
         working-directory: docs-site


### PR DESCRIPTION
Closes #11. Skips the broken docs:fix-urls step in the docs-deploy workflow — the rename it does is for Deno Deploy URL compatibility, unneeded on Cloudflare Workers. See commit message and #11 for full details.